### PR TITLE
Update module.xml

### DIFF
--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/narayana/rts/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/narayana/rts/main/module.xml
@@ -31,6 +31,7 @@
     </resources>
 
     <dependencies>
+        <module name="org.jboss.resteasy.resteasy-client"/>
         <module name="org.jboss.resteasy.resteasy-core-spi"/>
         <module name="org.jboss.resteasy.resteasy-core"/>
         <module name="org.jboss.resteasy.resteasy-jaxb-provider"/>


### PR DESCRIPTION
resteasy-client module is needed for rts submodule, see zulip stream https://narayana.zulipchat.com/#narrow/stream/323715-developers/topic/REST-AT.20bridge.20testCrashBeforeCommit.20recovery

