### PR TITLE
Patch 2

### DIFF
--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/narayana/rts/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/narayana/rts/main/module.xml
@@ -32,6 +32,7 @@
 
     <dependencies>
         <module name="org.jboss.resteasy.resteasy-core-spi"/>
+        <module name="org.jboss.resteasy.resteasy-client"/>
         <module name="org.jboss.resteasy.resteasy-core"/>
         <module name="org.jboss.resteasy.resteasy-jaxb-provider"/>
         <module name="org.jboss.resteasy.resteasy-json-p-provider"/>


### PR DESCRIPTION
resteasy-client module is needed for rts submodule, see zulip stream https://narayana.zulipchat.com/#narrow/stream/323715-developers/topic/REST-AT.20bridge.20testCrashBeforeCommit.20recovery